### PR TITLE
Pin checkout action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 


### PR DESCRIPTION
## Summary
- Pin the release workflow's checkout action to the current actions/checkout v4 commit SHA.

## Security context
- This prepares the repo for enabling the GitHub Actions repository setting that requires actions to be pinned to full-length commit SHAs.
- Repo Actions settings have already been tightened to read-only default GITHUB_TOKEN permissions and selected GitHub-owned actions only.

## Validation
- Verified the pinned SHA matches the current actions/checkout v4 tag target via git ls-remote.