### PR TITLE
feat: submit SDK releases to Release SBOM

### DIFF
--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -1,0 +1,46 @@
+name: Submit release dependency evidence
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the immutable release
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve released commit
+        id: release
+        run: echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate scoped collector token
+        id: collector-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_SBOM_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.RELEASE_SBOM_DISPATCH_APP_PRIVATE_KEY }}
+          owner: privy-io
+          repositories: security-automations
+
+      - name: Dispatch immutable release collection
+        env:
+          GH_TOKEN: ${{ steps.collector-token.outputs.token }}
+          RELEASED_COMMIT: ${{ steps.release.outputs.commit }}
+        run: |
+          gh workflow run release-sbom-collect-sdk-release.yml \
+            --repo privy-io/security-automations \
+            --ref main \
+            -f source_repository="${{ github.repository }}" \
+            -f source_commit="$RELEASED_COMMIT" \
+            -f release="${{ github.event.release.tag_name }}" \
+            -f package_name="PrivySDK" \
+            -f ecosystem="swift"


### PR DESCRIPTION
## Summary

Adds a release-triggered, authenticated dispatch to Privy Release SBOM. The workflow resolves the immutable release identity and uses a short-lived GitHub App token scoped to `privy-io/security-automations`; it receives no AWS credentials.

## Dependency

Draft until privy-io/security-automations#63 is merged and the repository has access to `RELEASE_SBOM_DISPATCH_APP_ID` and `RELEASE_SBOM_DISPATCH_APP_PRIVATE_KEY`.

## Validation

- inspected this repository’s canonical release workflow and package identity
- parsed the workflow as YAML
- pinned third-party Actions by commit SHA
- collection remains idempotent in the central service