### PR TITLE
ci: link iOS releases to changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          ANCHOR="${VERSION//./-}"
+
           gh release create "$VERSION" \
-            --title "$VERSION"
+            --title "$VERSION" \
+            --notes "See the [Privy iOS SDK $VERSION changelog](https://docs.privy.io/basics/swift/changelog#$ANCHOR) for release details."


### PR DESCRIPTION
## Summary

- add a changelog link to generated GitHub Release bodies
- link directly to the released version using the Mintlify heading anchor

## Validation

Updated the last couple releases which had empty bodies e.g. https://github.com/privy-io/privy-ios/releases/tag/2.12.0